### PR TITLE
Fix search for numeric search terms

### DIFF
--- a/script/interface.php
+++ b/script/interface.php
@@ -218,6 +218,12 @@ function _search($type, $keyword, $asArray=false) {
 					$sql_where.=' OR '.$table1.'.'.$fieldname." LIKE '%".$db->escape($keyword)."%'";
 				}
 				else if( strpos($tbl->Type,'smallint') !== false || strpos($tbl->Type,'double')!== false || strpos($tbl->Type,'float') !== false ) {
+					// Skip spatial and other incompatible types
+					if(strpos($tbl->Type,'point') !== false
+						|| strpos($tbl->Type,'geometry') !== false
+						|| strpos($tbl->Type,'spatial') !== false) {
+						continue;
+					}
 					$i_keyword = (double)$keyword;
 					if(!empty($i_keyword))$sql_where.=' OR '.$table1.'.'.$fieldname." = ".$i_keyword;
 
@@ -245,6 +251,12 @@ function _search($type, $keyword, $asArray=false) {
 					$sql_where.=' OR '.$table1.'.'.$fieldname." LIKE '%".$db->escape($keyword)."%'";
 				}
 				else if( strpos($tbl->Type,'int') !== false || strpos($tbl->Type,'double')!== false || strpos($tbl->Type,'float') !== false ) {
+					// Skip spatial and other incompatible types
+					if(strpos($tbl->Type,'point') !== false
+						|| strpos($tbl->Type,'geometry') !== false
+						|| strpos($tbl->Type,'spatial') !== false) {
+						continue;
+					}
 					$i_keyword = (double)$keyword;
 					if(!empty($i_keyword))$sql_where.=' OR '.$table1.'.'.$fieldname." = ".$i_keyword;
 				}


### PR DESCRIPTION
Numeric search terms generate a = comparison for numeric fields.

However, we now have also spatial numeric fields (point) in the DB which caused the SQL = comparison with the numeric search term to crash an return no results.

Without this change, search for numbers e.g. in descriptions does not return any results.